### PR TITLE
Plugin updates (ntc-netbox-plugin-onboarding)

### DIFF
--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -84,13 +84,29 @@ RQ_QUEUES = {
         "SSL": is_truthy(os.environ.get("REDIS_SSL", False)),
         "DEFAULT_TIMEOUT": 300,
     },
-    "check_releases": {
-        "HOST": os.environ["REDIS_HOST"],
+    "webhooks": {
+        "HOST": os.getenv("REDIS_HOST"),
         "PORT": int(os.environ.get("REDIS_PORT", 6379)),
         "DB": 0,
-        "PASSWORD": os.environ["REDIS_PASSWORD"],
+        "PASSWORD": os.getenv("REDIS_PASSWORD"),
         "SSL": is_truthy(os.environ.get("REDIS_SSL", False)),
         "DEFAULT_TIMEOUT": 300,
+    },
+    "check_releases": {
+        "HOST": os.getenv("REDIS_HOST"),
+        "PORT": int(os.environ.get("REDIS_PORT", 6379)),
+        "DB": 0,
+        "PASSWORD": os.getenv("REDIS_PASSWORD"),
+        "SSL": is_truthy(os.environ.get("REDIS_SSL", False)),
+        "DEFAULT_TIMEOUT": 300,
+    },
+    "custom_fields": {
+        "HOST": os.getenv("REDIS_HOST"),
+        "PORT": int(os.environ.get("REDIS_PORT", 6379)),
+        "DB": 0,
+        "PASSWORD": os.getenv("REDIS_PASSWORD"),
+        "SSL": is_truthy(os.environ.get("REDIS_SSL", False)),
+        "DEFAULT_TIMEOUT": 900,
     },
 }
 

--- a/nautobot_device_onboarding/migrations/0002_create_onboardingdevice.py
+++ b/nautobot_device_onboarding/migrations/0002_create_onboardingdevice.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+def create_missing_onboardingdevice(apps, schema_editor):
+    Device = apps.get_model("dcim", "Device")
+    OnboardingDevice = apps.get_model("nautobot_device_onboarding", "OnboardingDevice")
+
+    for device in Device.objects.filter(onboardingdevice__isnull=True):
+        OnboardingDevice.objects.create(device=device)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nautobot_device_onboarding", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_missing_onboardingdevice),
+    ]

--- a/nautobot_device_onboarding/models.py
+++ b/nautobot_device_onboarding/models.py
@@ -56,7 +56,7 @@ class OnboardingTask(BaseModel, ChangeLoggedModel):
 
     def __str__(self):
         """String representation of an OnboardingTask."""
-        return f"{self.site} : {self.ip_address}"
+        return f"{self.site} | {self.ip_address}"
 
     def get_absolute_url(self):
         """Provide absolute URL to an OnboardingTask."""

--- a/nautobot_device_onboarding/netdev_keeper.py
+++ b/nautobot_device_onboarding/netdev_keeper.py
@@ -178,7 +178,12 @@ class NetdevKeeper:
             logger.error("ERROR: %s", str(err))
             raise OnboardException(reason="fail-general", message=f"ERROR: {str(err)}")
 
-        logger.info("INFO device type is: %s", guessed_device_type)
+        else:
+            if guessed_device_type is None:
+                logger.error("ERROR: Could not detect device type with SSHDetect")
+                raise OnboardException(
+                    reason="fail-general", message="ERROR: Could not detect device type with SSHDetect"
+                )
 
         return guessed_device_type
 

--- a/nautobot_device_onboarding/templates/nautobot_device_onboarding/onboardingtask.html
+++ b/nautobot_device_onboarding/templates/nautobot_device_onboarding/onboardingtask.html
@@ -12,7 +12,7 @@
         </div>
     </div>
 
-    <h1>{% block title %}Device: {{ object.ip_address }}{% endblock %}</h1>
+    <h1>{% block title %}{{ object }}{% endblock %}</h1>
 
     <ul class="nav nav-tabs">
         <li role="presentation"{% if not active_tab %} class="active"{% endif %}>

--- a/nautobot_device_onboarding/tests/test_api.py
+++ b/nautobot_device_onboarding/tests/test_api.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
@@ -21,6 +21,8 @@ from nautobot.users.models import Token
 from nautobot.dcim.models import Site
 
 from nautobot_device_onboarding.models import OnboardingTask
+
+User = get_user_model()
 
 
 class OnboardingTaskTestCase(TestCase):

--- a/nautobot_device_onboarding/tests/test_nautobot_keeper.py
+++ b/nautobot_device_onboarding/tests/test_nautobot_keeper.py
@@ -15,6 +15,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from django.utils.text import slugify
+from nautobot.dcim.choices import InterfaceTypeChoices
 from nautobot.dcim.models import Site, Manufacturer, DeviceType, DeviceRole, Device, Interface, Platform
 from nautobot.ipam.models import IPAddress
 from nautobot.extras.models import Status
@@ -350,7 +351,7 @@ class NautobotKeeperTestCase(TestCase):
             serial="987654",
         )
 
-        intf = Interface.objects.create(name=netdev_mgmt_ifname, device=device)
+        intf = Interface.objects.create(name=netdev_mgmt_ifname, device=device, type=InterfaceTypeChoices.TYPE_OTHER)
 
         onboarding_kwargs = {
             "netdev_hostname": device_name,

--- a/nautobot_device_onboarding/worker.py
+++ b/nautobot_device_onboarding/worker.py
@@ -53,7 +53,7 @@ def onboard_device(task_id, credentials):  # pylint: disable=too-many-statements
     try:
         try:
             if ot.ip_address:
-                onboarded_device = Device.objects.get(primary_ip4__address__net_host=ot.ip_address)
+                onboarded_device = Device.objects.get(primary_ip4__host=ot.ip_address)
 
             if OnboardingDevice.objects.filter(device=onboarded_device, enabled=False):
                 ot.status = OnboardingStatusChoices.STATUS_SKIPPED

--- a/nautobot_device_onboarding/worker.py
+++ b/nautobot_device_onboarding/worker.py
@@ -36,7 +36,7 @@ REQUEST_TIME = Summary("onboardingtask_processing_seconds", "Time spent processi
 
 @REQUEST_TIME.time()
 @job("default")
-def onboard_device(task_id, credentials):  # pylint: disable=too-many-statements
+def onboard_device(task_id, credentials):  # pylint: disable=too-many-statements, too-many-branches
     """Process a single OnboardingTask instance."""
     username = credentials.username
     password = credentials.password
@@ -107,6 +107,10 @@ def onboard_device(task_id, credentials):  # pylint: disable=too-many-statements
         ot.message = str(exc)
         ot.save()
         onboarding_status = False
+
+    finally:
+        if onboarded_device and not OnboardingDevice.objects.filter(device=onboarded_device):
+            OnboardingDevice.objects.create(device=onboarded_device)
 
     onboardingtask_results_counter.labels(status=ot.status).inc()
 

--- a/tasks.py
+++ b/tasks.py
@@ -16,7 +16,7 @@ import os
 from invoke import task
 
 PYTHON_VER = os.getenv("PYTHON_VER", "3.7")
-NAUTOBOT_VER = os.getenv("NAUTOBOT_VER", "main")
+NAUTOBOT_VER = os.getenv("NAUTOBOT_VER", "1.0.0b4")
 
 # Name of the docker image/container
 NAME = os.getenv("IMAGE_NAME", "nautobot-device-onboarding")


### PR DESCRIPTION
This PR ports two known issues solved in the NetBox version of the onboarding plugin. (migrations related)

Additionally, PR aligns with Nautobot 1.0.0b4 and contains fixes for :

- IP filtering (closes #9)
- Str representation of OnboardingTask object
- Fix for TYPE of interface created during onboarding
- Unit tests alignments
- Nautobot_config updates