### PR TITLE
Update to OnboardingTask tasks views and models to replace UUID with …

### DIFF
--- a/nautobot_device_onboarding/migrations/0003_onboardingtask_label.py
+++ b/nautobot_device_onboarding/migrations/0003_onboardingtask_label.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+def create_labels_for_existing_tasks(apps, schema_editor):
+    OnboardingTask = apps.get_model("nautobot_device_onboarding", "OnboardingTask")
+
+    for index, task_object in enumerate(OnboardingTask.objects.order_by("created"), start=1):
+        task_object.label = index
+        task_object.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nautobot_device_onboarding", "0002_create_onboardingdevice"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="onboardingtask",
+            name="label",
+            field=models.PositiveIntegerField(default=0, editable=False),
+        ),
+        migrations.RunPython(create_labels_for_existing_tasks),
+    ]

--- a/nautobot_device_onboarding/tables.py
+++ b/nautobot_device_onboarding/tables.py
@@ -20,7 +20,7 @@ class OnboardingTaskTable(BaseTable):
     """Table for displaying OnboardingTask instances."""
 
     pk = ToggleColumn()
-    id = tables.LinkColumn()
+    label = tables.LinkColumn()
     site = tables.LinkColumn()
     platform = tables.LinkColumn()
     created_device = tables.LinkColumn()
@@ -29,7 +29,7 @@ class OnboardingTaskTable(BaseTable):
         model = OnboardingTask
         fields = (
             "pk",
-            "id",
+            "label",
             "created",
             "ip_address",
             "site",
@@ -49,7 +49,7 @@ class OnboardingTaskFeedBulkTable(BaseTable):
     class Meta(BaseTable.Meta):  # noqa: D106 "Missing docstring in public nested class"
         model = OnboardingTask
         fields = (
-            "id",
+            "label",
             "created",
             "site",
             "platform",

--- a/nautobot_device_onboarding/templates/nautobot_device_onboarding/onboardingtask.html
+++ b/nautobot_device_onboarding/templates/nautobot_device_onboarding/onboardingtask.html
@@ -35,6 +35,10 @@
             </div>
             <table class="table table-hover panel-body attr-table">
                 <tr>
+                    <td>Label</td>
+                    <td>{{ object.label|placeholder }}</td>
+                </tr>
+                <tr>
                     <td>Created Device</td>
                     <td>{{ object.created_device|placeholder }}</td>
                 </tr>

--- a/nautobot_device_onboarding/tests/test_models.py
+++ b/nautobot_device_onboarding/tests/test_models.py
@@ -98,3 +98,8 @@ class OnboardingDeviceModelTestCase(TestCase):
         """Verify OnboardingDevice last ot."""
         onboarding_device = OnboardingDevice.objects.get(device=self.device)
         self.assertEqual(onboarding_device.last_ot, self.failed_task2)
+
+    def test_tasks_labels(self):
+        """Verify created tasks are with labels following creation order."""
+        for index, task_object in enumerate(OnboardingTask.objects.order_by("created"), start=1):
+            self.assertEqual(index, task_object.label)

--- a/nautobot_device_onboarding/views.py
+++ b/nautobot_device_onboarding/views.py
@@ -40,7 +40,7 @@ class OnboardingTaskView(generic.ObjectView):
 class OnboardingTaskListView(generic.ObjectListView):
     """View for listing all extant OnboardingTasks."""
 
-    queryset = OnboardingTask.objects.all().order_by("-id")
+    queryset = OnboardingTask.objects.all().order_by("-label")
     filterset = OnboardingTaskFilter
     filterset_form = OnboardingTaskFilterForm
     table = OnboardingTaskTable


### PR DESCRIPTION
I couldn't use `AutoFied()` as it needs to be `primary_key` and and there is already other `primary_key` existing - I think UUID, so I used `PositiveSmallIntegerFieldinstead()` instead.

I created a private method to get the latest ID, but maybe there is a more elegant way to do that.

There was a request in the issue #22 to add tests for existing objects without label, but I am not sure how to update tests if models are already updated and all objects are created from within updated models.

Comments are welcome.