### PR TITLE
Remove per file license

### DIFF
--- a/docs/examples/example_ios_set_device_role.py
+++ b/docs/examples/example_ios_set_device_role.py
@@ -1,16 +1,4 @@
-"""Example of custom onboarding class.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Example of custom onboarding class."""
 
 from nautobot_device_onboarding.nautobot_keeper import NautobotKeeper
 from nautobot_device_onboarding.onboarding.onboarding import Onboarding

--- a/nautobot_device_onboarding/__init__.py
+++ b/nautobot_device_onboarding/__init__.py
@@ -1,16 +1,4 @@
-"""Plugin declaration for nautobot_device_onboarding.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Plugin declaration for nautobot_device_onboarding."""
 
 from nautobot.extras.plugins import PluginConfig
 

--- a/nautobot_device_onboarding/admin.py
+++ b/nautobot_device_onboarding/admin.py
@@ -1,16 +1,4 @@
-"""Administrative capabilities for nautobot_device_onboarding plugin.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Administrative capabilities for nautobot_device_onboarding plugin."""
 from django.contrib import admin
 from .models import OnboardingTask
 

--- a/nautobot_device_onboarding/api/serializers.py
+++ b/nautobot_device_onboarding/api/serializers.py
@@ -1,16 +1,4 @@
-"""Model serializers for the nautobot_device_onboarding REST API.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Model serializers for the nautobot_device_onboarding REST API."""
 
 from rest_framework import serializers
 

--- a/nautobot_device_onboarding/api/urls.py
+++ b/nautobot_device_onboarding/api/urls.py
@@ -1,16 +1,4 @@
-"""REST API URLs for device onboarding.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""REST API URLs for device onboarding."""
 
 from rest_framework import routers
 from .views import OnboardingTaskView

--- a/nautobot_device_onboarding/api/views.py
+++ b/nautobot_device_onboarding/api/views.py
@@ -1,16 +1,4 @@
-"""Django REST Framework API views for device onboarding.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Django REST Framework API views for device onboarding."""
 
 # from drf_yasg.openapi import Parameter, TYPE_STRING
 # from drf_yasg.utils import swagger_auto_schema

--- a/nautobot_device_onboarding/choices.py
+++ b/nautobot_device_onboarding/choices.py
@@ -1,16 +1,4 @@
-"""ChoiceSet classes for device onboarding.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""ChoiceSet classes for device onboarding."""
 
 from nautobot.utilities.choices import ChoiceSet
 

--- a/nautobot_device_onboarding/exceptions.py
+++ b/nautobot_device_onboarding/exceptions.py
@@ -1,16 +1,4 @@
-"""Exceptions.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Exceptions."""
 
 
 class OnboardException(Exception):

--- a/nautobot_device_onboarding/filters.py
+++ b/nautobot_device_onboarding/filters.py
@@ -1,16 +1,4 @@
-"""Filtering logic for OnboardingTask instances.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Filtering logic for OnboardingTask instances."""
 
 import django_filters
 from django.db.models import Q

--- a/nautobot_device_onboarding/forms.py
+++ b/nautobot_device_onboarding/forms.py
@@ -1,16 +1,4 @@
-"""Forms for network device onboarding.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Forms for network device onboarding."""
 
 from django import forms
 from django.db import transaction

--- a/nautobot_device_onboarding/helpers.py
+++ b/nautobot_device_onboarding/helpers.py
@@ -1,16 +1,4 @@
-"""OnboardingTask Django model.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""OnboardingTask Django model."""
 
 import socket
 

--- a/nautobot_device_onboarding/metrics.py
+++ b/nautobot_device_onboarding/metrics.py
@@ -1,16 +1,4 @@
-"""Plugin additions to the Nautobot navigation menu.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Plugin additions to the Nautobot navigation menu."""
 from prometheus_client import Counter
 
 onboardingtask_results_counter = Counter(

--- a/nautobot_device_onboarding/models.py
+++ b/nautobot_device_onboarding/models.py
@@ -1,16 +1,4 @@
-"""OnboardingTask Django model.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""OnboardingTask Django model."""
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.db import models

--- a/nautobot_device_onboarding/nautobot_keeper.py
+++ b/nautobot_device_onboarding/nautobot_keeper.py
@@ -1,16 +1,4 @@
-"""Nautobot Keeper.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Nautobot Keeper."""
 
 import logging
 import re

--- a/nautobot_device_onboarding/navigation.py
+++ b/nautobot_device_onboarding/navigation.py
@@ -1,16 +1,4 @@
-"""Plugin additions to the Nautobot navigation menu.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Plugin additions to the Nautobot navigation menu."""
 
 from nautobot.extras.plugins import PluginMenuButton, PluginMenuItem
 from nautobot.utilities.choices import ButtonColorChoices

--- a/nautobot_device_onboarding/netdev_keeper.py
+++ b/nautobot_device_onboarding/netdev_keeper.py
@@ -1,16 +1,4 @@
-"""NetDev Keeper.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""NetDev Keeper."""
 
 import importlib
 import logging

--- a/nautobot_device_onboarding/onboard.py
+++ b/nautobot_device_onboarding/onboard.py
@@ -1,16 +1,4 @@
-"""Onboard.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Onboard."""
 
 from django.conf import settings
 

--- a/nautobot_device_onboarding/onboarding/__init__.py
+++ b/nautobot_device_onboarding/onboarding/__init__.py
@@ -1,13 +1,1 @@
-"""Onboarding.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Onboarding."""

--- a/nautobot_device_onboarding/onboarding/onboarding.py
+++ b/nautobot_device_onboarding/onboarding/onboarding.py
@@ -1,16 +1,4 @@
-"""Onboarding module.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Onboarding module."""
 
 from nautobot_device_onboarding.nautobot_keeper import NautobotKeeper
 

--- a/nautobot_device_onboarding/onboarding_extensions/__init__.py
+++ b/nautobot_device_onboarding/onboarding_extensions/__init__.py
@@ -1,13 +1,1 @@
-"""Onboarding Extensions.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Onboarding Extensions."""

--- a/nautobot_device_onboarding/onboarding_extensions/ios.py
+++ b/nautobot_device_onboarding/onboarding_extensions/ios.py
@@ -1,16 +1,4 @@
-"""Onboarding Extension for IOS.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Onboarding Extension for IOS."""
 
 from nautobot_device_onboarding.onboarding.onboarding import StandaloneOnboarding
 

--- a/nautobot_device_onboarding/tables.py
+++ b/nautobot_device_onboarding/tables.py
@@ -1,16 +1,4 @@
-"""Tables for device onboarding tasks.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Tables for device onboarding tasks."""
 import django_tables2 as tables
 from nautobot.utilities.tables import BaseTable, ToggleColumn
 from .models import OnboardingTask

--- a/nautobot_device_onboarding/template_content.py
+++ b/nautobot_device_onboarding/template_content.py
@@ -1,16 +1,4 @@
-"""Onboarding template content.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Onboarding template content."""
 
 from nautobot.extras.plugins import PluginTemplateExtension
 from .models import OnboardingDevice

--- a/nautobot_device_onboarding/tests/test_api.py
+++ b/nautobot_device_onboarding/tests/test_api.py
@@ -1,16 +1,4 @@
-"""Unit tests for nautobot_device_onboarding REST API.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Unit tests for nautobot_device_onboarding REST API."""
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse

--- a/nautobot_device_onboarding/tests/test_models.py
+++ b/nautobot_device_onboarding/tests/test_models.py
@@ -1,16 +1,4 @@
-"""Unit tests for nautobot_device_onboarding OnboardingDevice model.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Unit tests for nautobot_device_onboarding OnboardingDevice model."""
 from django.test import TestCase
 
 from nautobot.dcim.models import Site, DeviceRole, DeviceType, Manufacturer, Device, Interface

--- a/nautobot_device_onboarding/tests/test_nautobot_keeper.py
+++ b/nautobot_device_onboarding/tests/test_nautobot_keeper.py
@@ -1,16 +1,4 @@
-"""Unit tests for nautobot_device_onboarding.onboard module and its classes.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Unit tests for nautobot_device_onboarding.onboard module and its classes."""
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase

--- a/nautobot_device_onboarding/tests/test_netdev_keeper.py
+++ b/nautobot_device_onboarding/tests/test_netdev_keeper.py
@@ -1,16 +1,4 @@
-"""Unit tests for nautobot_device_onboarding.netdev_keeper module and its classes.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Unit tests for nautobot_device_onboarding.netdev_keeper module and its classes."""
 
 from socket import gaierror
 from unittest import mock

--- a/nautobot_device_onboarding/tests/test_onboarding.py
+++ b/nautobot_device_onboarding/tests/test_onboarding.py
@@ -1,16 +1,4 @@
-"""Unit tests for nautobot_device_onboarding.netdev_keeper module and its classes.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Unit tests for nautobot_device_onboarding.netdev_keeper module and its classes."""
 
 from unittest import mock
 

--- a/nautobot_device_onboarding/tests/test_views.py
+++ b/nautobot_device_onboarding/tests/test_views.py
@@ -1,16 +1,4 @@
-"""Unit tests for nautobot_device_onboarding views.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Unit tests for nautobot_device_onboarding views."""
 from nautobot.dcim.models import Site
 from nautobot.utilities.testing import ViewTestCases
 

--- a/nautobot_device_onboarding/urls.py
+++ b/nautobot_device_onboarding/urls.py
@@ -1,16 +1,4 @@
-"""Django urlpatterns declaration for nautobot_device_onboarding plugin.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Django urlpatterns declaration for nautobot_device_onboarding plugin."""
 from django.urls import path
 from nautobot.extras.views import ObjectChangeLogView
 

--- a/nautobot_device_onboarding/utils/credentials.py
+++ b/nautobot_device_onboarding/utils/credentials.py
@@ -1,16 +1,4 @@
-"""User credentials helper module for device onboarding.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""User credentials helper module for device onboarding."""
 
 
 class Credentials:

--- a/nautobot_device_onboarding/views.py
+++ b/nautobot_device_onboarding/views.py
@@ -1,16 +1,4 @@
-"""Django views for device onboarding.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Django views for device onboarding."""
 import logging
 
 from django.shortcuts import get_object_or_404, render

--- a/nautobot_device_onboarding/worker.py
+++ b/nautobot_device_onboarding/worker.py
@@ -1,16 +1,4 @@
-"""Worker code for processing inbound OnboardingTasks.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Worker code for processing inbound OnboardingTasks."""
 import logging
 
 from django.core.exceptions import ValidationError

--- a/tasks.py
+++ b/tasks.py
@@ -1,16 +1,4 @@
-"""Tasks for use with Invoke.
-
-(c) 2020-2021 Network To Code
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Tasks for use with Invoke."""
 
 from distutils.util import strtobool
 from invoke import Collection, task as invoke_task


### PR DESCRIPTION
The license per file is not required, is not being maintained (it is nearly 2023), and is not consistent. Let's remove it and rid ourselves of the minor tech debt. 