### PR TITLE
Bump Version to 1.2.0-beta.1

### DIFF
--- a/nautobot_device_onboarding/__init__.py
+++ b/nautobot_device_onboarding/__init__.py
@@ -11,10 +11,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+try:
+    from importlib import metadata
+except ImportError:
+    # Python version < 3.8
+    import importlib_metadata as metadata
+
+__version__ = metadata.version(__name__)
 
 from nautobot.extras.plugins import PluginConfig
-
-__version__ = "1.1.2"
 
 
 class OnboardingConfig(PluginConfig):
@@ -23,7 +28,7 @@ class OnboardingConfig(PluginConfig):
     name = "nautobot_device_onboarding"
     verbose_name = "Device Onboarding"
     version = __version__
-    min_version = "1.0.0"
+    min_version = "1.5.0"
     author = "Network to Code"
     author_email = "opensource@networktocode.com"
     description = "A plugin for Nautobot to easily onboard new devices."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-device-onboarding"
-version = "1.1.2"
+version = "1.2.0-beta.1"
 description = "A plugin for Nautobot to easily onboard new devices."
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
With several updates pending (docs, ntc standards, etc) I think it makes sense to bump the version and set the new floor. 