### PR TITLE
Add options to assign secret group and mgmt only interface status

### DIFF
--- a/docs/admin/install.md
+++ b/docs/admin/install.md
@@ -91,6 +91,8 @@ Although the plugin can run without providing any settings, the plugin behavior 
 - `default_management_prefix_length` integer ( default 0), length of the prefix that will be used for the management IP address, if the IP can't be found.
 - `skip_device_type_on_update` boolean (default False), If True, an existing Nautobot device will not get its device type updated. If False, device type will be updated with one discovered on a device.
 - `skip_manufacturer_on_update` boolean (default False), If True, an existing Nautobot device will not get its manufacturer updated. If False, manufacturer will be updated with one discovered on a device.
+- `assign_secrets_group` boolean (default False), If True, the credentials used to connect to the device will be assigned as the secrets group for the device upon creation. If False, no secrets group will be assigned.
+- `set_management_only_interface` boolean (default False), If True, the interface that is created or updated will be set to management only. If False, the interface will be set to not be management only.
 - `platform_map` (dictionary), mapping of an **auto-detected** Netmiko platform to the **Nautobot slug** name of your Platform. The dictionary should be in the format:
     ```python
     {

--- a/nautobot_device_onboarding/__init__.py
+++ b/nautobot_device_onboarding/__init__.py
@@ -34,6 +34,8 @@ class NautobotDeviceOnboardingConfig(NautobotAppConfig):
         "skip_device_type_on_update": False,
         "skip_manufacturer_on_update": False,
         "platform_map": {},
+        "assign_secrets_group": False,
+        "set_management_only_interface": False,
         "onboarding_extensions_map": {
             "ios": "nautobot_device_onboarding.onboarding_extensions.ios",
         },

--- a/nautobot_device_onboarding/jobs.py
+++ b/nautobot_device_onboarding/jobs.py
@@ -72,6 +72,7 @@ class OnboardingTask(Job):  # pylint: disable=too-many-instance-attributes
         self.location = None
         self.device_type = None
         self.role = None
+        self.credentials = None
         super().__init__(*args, **kwargs)
 
     def run(self, *args, **data):
@@ -83,6 +84,7 @@ class OnboardingTask(Job):  # pylint: disable=too-many-instance-attributes
         self.location = data["location"]
         self.device_type = data["device_type"]
         self.role = data["role"]
+        self.credentials = data["credentials"]
 
         self.logger.info("START: onboarding devices")
         # allows for itteration without having to spawn multiple jobs
@@ -126,6 +128,7 @@ class OnboardingTask(Job):  # pylint: disable=too-many-instance-attributes
             "netdev_nb_role_name": self.role.name if self.role else PLUGIN_SETTINGS["default_device_role"],
             "netdev_nb_role_color": PLUGIN_SETTINGS["default_device_role_color"],
             "netdev_nb_platform_name": self.platform.name if self.platform else None,
+            "netdev_nb_credentials": self.credentials if PLUGIN_SETTINGS["assign_secrets_group"] else None,
             # Kwargs discovered on the Onboarded Device:
             "netdev_hostname": netdev_dict["netdev_hostname"],
             "netdev_vendor": netdev_dict["netdev_vendor"],

--- a/nautobot_device_onboarding/nautobot_keeper.py
+++ b/nautobot_device_onboarding/nautobot_keeper.py
@@ -481,7 +481,7 @@ class NautobotKeeper:  # pylint: disable=too-many-instance-attributes
             self.device.save()
 
     def ensure_secret_group(self):
-        """Optionally assign secret group from onboarding to created/updated device"""
+        """Optionally assign secret group from onboarding to created/updated device."""
         if PLUGIN_SETTINGS["assign_secrets_group"]:
             self.device.secrets_group = self.netdev_nb_credentials
             self.device.validated_save()


### PR DESCRIPTION
Related to issue #133 , added the feature to assign the secret group used in onboarding to the device upon creation/update. Additionally added the feature to set the IP used with onboarding as managment only. 